### PR TITLE
Abstract away the Reqwest dependency to allow other HTTP client implementations like Hyper.

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -24,9 +24,10 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: clippy
-          args: --all-targets -- --deny warnings
+          args: --all-targets --all-features -- --deny warnings
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
+          args: --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,33 @@ tower-service = {version = "*", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+hyper-tls = "0.5.0"
 
 [features]
 default = ["reqwest-client"]
-hyper-client = ["base64", "hyper", "tokio", "tower-service"]
+hyper-client = ["base64", "hyper/client", "hyper/http1", "hyper/http2", "tokio", "tower-service"]
 reqwest-client = ["reqwest"]
+
+[[example]]
+name = "github"
+required-features = ["reqwest-client"]
+
+[[example]]
+name = "google-web"
+required-features = ["reqwest-client"]
+
+[[example]]
+name = "google-installed"
+required-features = ["reqwest-client"]
+
+[[example]]
+name = "imgur"
+required-features = ["reqwest-client"]
+
+[[test]]
+name = "auth_uri"
+required-features = ["reqwest-client"]
+
+[[test]]
+name = "hyper-client"
+required-features = ["hyper-client"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,27 @@ repository = "https://github.com/wfraser/inth-oauth2-async"
 readme = "README.md"
 
 [dependencies]
+async-trait = "0.1.50"
 chrono = { version = "0.4", features = ["serde"] }
 lazy_static = "1.1.0"
 serde = "1.0.8"
 serde_derive = "1.0.5"
 serde_json = "1.0.2"
 url = "2.2.2"
-reqwest = "0.11.3"
+
+# Reqwest client:
+reqwest = { version = "0.11.3", optional = true }
+
+# Hyper client:
+base64 = { version = "*", optional = true }
+hyper = { version = "0.14", optional = true }
+tokio = { version = "*", optional = true }
+tower-service = {version = "*", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[features]
+default = ["reqwest-client"]
+hyper-client = ["base64", "hyper", "tokio", "tower-service"]
+reqwest-client = ["reqwest"]

--- a/src/client/http_client.rs
+++ b/src/client/http_client.rs
@@ -1,0 +1,114 @@
+//! HTTP client abstraction and implementations.
+//!
+//! We provide out-of-the-box implementations for two crates: Hyper, and Reqwest; both of which are
+//! gated by Cargo features. The [`HttpClient`] trait can alternatively be implemented for any other
+//! client type you need.
+
+use crate::client::error::ClientError;
+
+/// Abstraction of the parts of a HTTP client implementation that this crate needs.
+#[async_trait::async_trait]
+pub trait HttpClient {
+    /// Make a HTTP POST request.
+    ///
+    /// [`client_id`] and [`client_secret`] are to be given as HTTP Basic Auth credentials username
+    /// and password, respectively.
+    ///
+    /// The [`body`] is of content-type `application/x-www-form-urlencoded`, and the response body
+    /// is expected to be `application/json`.
+    ///
+    /// The response body must be deserialized into a json value.
+    async fn post(
+        &self,
+        url: &str,
+        client_id: &str,
+        client_secret: &str,
+        body: String,
+    ) -> Result<serde_json::Value, ClientError>;
+}
+
+/// Implementation for Reqwest.
+#[cfg(feature = "reqwest-client")]
+pub mod reqwest_client {
+    use super::*;
+    use reqwest::header::{ACCEPT, CONTENT_TYPE};
+
+    #[async_trait::async_trait]
+    impl HttpClient for reqwest::Client {
+        async fn post(
+            &self,
+            url: &str,
+            client_id: &str,
+            client_secret: &str,
+            body: String,
+        ) -> Result<serde_json::Value, ClientError> {
+            let response = reqwest::Client::post(self, url)
+                .basic_auth(client_id, Some(client_secret))
+                .header(ACCEPT, "application/json")
+                .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(body)
+                .send()
+                .await?;
+
+            let full = response.bytes().await?;
+            let json = serde_json::from_slice(&full)?;
+
+            Ok(json)
+        }
+    }
+}
+
+/// Implementation for Hyper
+#[cfg(feature = "hyper-client")]
+pub mod hyper_client {
+    use super::*;
+    use base64::write::EncoderWriter as Base64Encoder;
+    use hyper::body::HttpBody;
+    use hyper::client::connect::Connection;
+    use hyper::header::{AUTHORIZATION, ACCEPT, CONTENT_TYPE, HeaderValue};
+    use hyper::Request;
+    use std::io::Write;
+    use tokio::io::{AsyncRead, AsyncWrite};
+    use tower_service::Service;
+
+    #[async_trait::async_trait]
+    impl<C, B> HttpClient for hyper::Client<C, B> where
+        // (°ー°) ...
+        C: Service<hyper::Uri> + Clone + Send + Sync + 'static,
+        C::Response: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
+        C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+        C::Future: Unpin + Send,
+        B: HttpBody + From<String> + Send + 'static,
+        B::Data: Send,
+        B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    {
+        async fn post(
+            &self,
+            url: &str,
+            client_id: &str,
+            client_secret: &str,
+            body: String,
+        ) -> Result<serde_json::Value, ClientError> {
+            let mut auth_header = b"Basic ".to_vec();
+            {
+                let mut enc = Base64Encoder::new(&mut auth_header, base64::STANDARD);
+                write!(enc, "{}:{}", client_id, client_secret)?;
+            }
+
+            let mut auth_header_val = HeaderValue::from_bytes(&auth_header)
+                .expect("invalid header value"); // should never happen for base64 data
+            auth_header_val.set_sensitive(true);
+
+            let req = Request::post(url)
+                .header(AUTHORIZATION, auth_header_val)
+                .header(ACCEPT, "application/json")
+                .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(body.into())?;
+
+            let mut response = self.request(req).await?;
+            let full = hyper::body::to_bytes(response.body_mut()).await?;
+            let json = serde_json::from_slice(&full)?;
+            Ok(json)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@
 //! ### Requesting an access token
 //!
 //! ```no_run
+//! # #[cfg(feature="reqwest-client")] {
 //! use std::io;
 //! use inth_oauth2_async::{Client, Token};
 //! # use inth_oauth2_async::provider::google::Installed;
@@ -68,12 +69,13 @@
 //! let http = reqwest::Client::new();
 //! let token = client.request_token(&http, code.trim()).await.unwrap();
 //! println!("{}", token.access_token());
-//! # }
+//! # } }
 //! ```
 //!
 //! ### Refreshing an access token
 //!
 //! ```no_run
+//! # #[cfg(feature="reqwest-client")] {
 //! # use inth_oauth2_async::Client;
 //! # use inth_oauth2_async::provider::google::Installed;
 //! # #[tokio::main]
@@ -82,12 +84,13 @@
 //! # let http = reqwest::Client::new();
 //! # let token = client.request_token(&http, "").await.unwrap();
 //! let token = client.refresh_token(&http, token, None).await.unwrap();
-//! # }
+//! # } }
 //! ```
 //!
 //! ### Ensuring an access token is still valid
 //!
 //! ```no_run
+//! # #[cfg(feature="reqwest-client")] {
 //! # use inth_oauth2_async::Client;
 //! # use inth_oauth2_async::provider::google::Installed;
 //! # #[tokio::main]
@@ -97,12 +100,13 @@
 //! # let mut token = client.request_token(&http, "").await.unwrap();
 //! // Refresh token only if it has expired.
 //! token = client.ensure_token(&http, token).await.unwrap();
-//! # }
+//! # } }
 //! ```
 //!
 //! ### Using bearer access tokens
 //!
 //! ```no_run
+//! # #[cfg(feature="reqwest-client")] {
 //! # use inth_oauth2_async::Client;
 //! # use inth_oauth2_async::provider::google::Installed;
 //! use inth_oauth2_async::Token;
@@ -115,7 +119,7 @@
 //! let request = http.get("https://example.com/resource")
 //!     .bearer_auth(token.access_token())
 //!     .build();
-//! # }
+//! # } }
 //! ```
 //!
 //! ### Persisting tokens
@@ -123,7 +127,7 @@
 //! All token types implement `Serialize` and `Deserialize` from `serde`.
 //!
 //! ```no_run
-//! extern crate serde_json;
+//! # #[cfg(feature="reqwest-client")] {
 //! # use inth_oauth2_async::Client;
 //! # use inth_oauth2_async::provider::google::Installed;
 //! # #[tokio::main]
@@ -132,7 +136,7 @@
 //! # let client = Client::new(Installed, String::new(), String::new(), None);
 //! # let token = client.request_token(&http, "").await.unwrap();
 //! let json = serde_json::to_string(&token).unwrap();
-//! # }
+//! # } }
 //! ```
 
 #![warn(

--- a/tests/hyper-client.rs
+++ b/tests/hyper-client.rs
@@ -1,0 +1,31 @@
+use hyper_tls::HttpsConnector;
+use inth_oauth2_async::{
+    Client,
+    error::{OAuth2Error, OAuth2ErrorCode},
+    client::ClientError,
+    provider,
+};
+
+// Mostly this test is just to verify that the client abstraction works with a typical Hyper client
+// instantiation.
+#[tokio::test]
+async fn test_hyper_client() {
+    let tls = HttpsConnector::new();
+    let hyper = hyper::client::Client::builder().build::<_, hyper::Body>(tls);
+
+    let client = Client::new(
+        provider::google::Web,
+        "foo".to_owned(),
+        "bar".to_owned(),
+        Some("https://example.com/squeedleedee".to_owned()),
+    );
+
+    let result = client.request_token(&hyper, "spoopadoop")
+        .await;
+
+    eprintln!("result: {:?}", result);
+    assert!(matches!(
+        result,
+        Err(ClientError::OAuth2(OAuth2Error { code: OAuth2ErrorCode::InvalidClient, .. }))
+    ));
+}


### PR DESCRIPTION
This includes implementations for two crates: Hyper and Reqwest.

Reqwest is enabled by default, so this is not a breaking change for any existing user, but it's a significant change and might warrant bumping the minor version anyway.